### PR TITLE
Add scraper execution route

### DIFF
--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,3 +1,8 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 import scraper
 
 


### PR DESCRIPTION
## Summary
- execute `scraper.py` from a new POST endpoint `/run-scraper`
- capture the script output and validate generated files
- document the endpoint in swagger automatically
- fix tests to import `scraper` module correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68419139cd48832ab037a38f2674d57d