### PR TITLE
feat: add interactive map component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.svelte-kit/
+build/
+__pycache__/
+output_data/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "just-testing",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "echo \"No frontend tests specified\""
+  },
+  "dependencies": {
+    "maplibre-gl": "^3.5.0"
+  }
+}

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import { onMount, createEventDispatcher } from 'svelte';
+  import maplibregl, { Map } from 'maplibre-gl';
+  import 'maplibre-gl/dist/maplibre-gl.css';
+
+  const DEFAULT_STYLE = 'https://demotiles.maplibre.org/style.json';
+  const styleUrl = import.meta.env.VITE_MAP_STYLE || DEFAULT_STYLE;
+
+  const dispatch = createEventDispatcher<{ load: { map: Map } }>();
+
+  let container: HTMLDivElement;
+  let map: Map;
+
+  onMount(() => {
+    map = new maplibregl.Map({
+      container,
+      style: styleUrl,
+      center: [11.576124, 48.137154],
+      zoom: 10
+    });
+
+    map.addControl(new maplibregl.NavigationControl(), 'top-right');
+    map.addControl(new maplibregl.ScaleControl(), 'bottom-left');
+
+    map.on('load', () => dispatch('load', { map }));
+
+    return () => map.remove();
+  });
+</script>
+
+<div bind:this={container} class="w-full h-full"></div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import Map from '$lib/components/Map.svelte';
+
+  function handleLoad(event: CustomEvent) {
+    const map = event.detail.map;
+    // Placeholder for dynamic layer handling
+    console.log('Map loaded', map);
+  }
+</script>
+
+<div class="w-screen h-screen">
+  <Map on:load={handleLoad} />
+</div>


### PR DESCRIPTION
## Summary
- add Map.svelte component with MapLibre base map and controls
- wire Map component into sample +page.svelte
- declare maplibre-gl dependency and frontend test script

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68906c179204832a90c873d23d37d205